### PR TITLE
Update links in docs

### DIFF
--- a/knotty/scribblings/io.scrbl
+++ b/knotty/scribblings/io.scrbl
@@ -49,7 +49,7 @@ the text-based format XML. Since this is a text file, you can load it into a
 web browser or text editor and view the data directly.
 
 The data format is defined in a separate file called a schema. The
-@hyperlink{https://github.com/t0mpr1c3/knotty/blob/main/xml/knotty.xsd
+@hyperlink{https://github.com/t0mpr1c3/knotty/blob/main/knotty-lib/resources/xml/knotty.xsd
  Knotty schema} will always be freely available. This means that you truly
 own your Knotty patterns, and will always be able to use them without
 restriction.

--- a/knotty/scribblings/ref.scrbl
+++ b/knotty/scribblings/ref.scrbl
@@ -558,13 +558,7 @@ styles as well: for more information, see the @racket[sweet-exp]
  bytes?]{
  Saves a Knotty Pattern data structure as an XML file with schema
  @hyperlink{https://github.com/t0mpr1c3/knotty/blob/main/knotty-lib/resources/xml/knotty.xsd
-  knotty.xsd}.  This XML format can be converted directly to an HTML page of
- knitting instructions using the stylesheet
- @hyperlink{https://github.com/t0mpr1c3/knotty/blob/main/xml/knotty-text.xsl
-  knotty-text.xsl}.  It can also be turned into a color knitting chart using the
- stylesheet
- @hyperlink{https://github.com/t0mpr1c3/knotty/blob/main/xml/knotty-chart.xsl
-  knotty-chart.xsl}.}
+  knotty.xsd}.}
 
 @defproc[
  (save

--- a/knotty/scribblings/ref.scrbl
+++ b/knotty/scribblings/ref.scrbl
@@ -542,7 +542,7 @@ styles as well: for more information, see the @racket[sweet-exp]
   [filename path-string?])
  Pattern?]{
  Loads a Knotty pattern from an XML file. The XML schema should conform to
- @hyperlink{https://github.com/t0mpr1c3/knotty/blob/main/xml/knotty.xsd
+ @hyperlink{https://github.com/t0mpr1c3/knotty/blob/main/knotty-lib/resources/xml/knotty.xsd
   knotty.xsd}.}
 
 @defproc[
@@ -557,7 +557,7 @@ styles as well: for more information, see the @racket[sweet-exp]
   [filename path-string?])
  bytes?]{
  Saves a Knotty Pattern data structure as an XML file with schema
- @hyperlink{https://github.com/t0mpr1c3/knotty/blob/main/xml/knotty.xsd
+ @hyperlink{https://github.com/t0mpr1c3/knotty/blob/main/knotty-lib/resources/xml/knotty.xsd
   knotty.xsd}.  This XML format can be converted directly to an HTML page of
  knitting instructions using the stylesheet
  @hyperlink{https://github.com/t0mpr1c3/knotty/blob/main/xml/knotty-text.xsl


### PR DESCRIPTION
I found some broken links in the docs,

- The url of `knotty.xsd` has been updated
- Links to `knotty-text.xsl` and `knotty-chart.xsl` were removed as those files are not in the repo (not sure if this is correct)